### PR TITLE
Added draggable option to allow/disallow dragging

### DIFF
--- a/locationpicker.jquery.js
+++ b/locationpicker.jquery.js
@@ -10,7 +10,7 @@
             position: new google.maps.LatLng(54.19335, -3.92695),
             map: _map,
             title: "Drag Me",
-            draggable: true
+            draggable: options.draggable
         });
         return {
             map: _map,
@@ -226,7 +226,8 @@
                 streetViewControl: false,
                 radius: settings.radius,
                 locationName: settings.locationName,
-                settings: settings
+                settings: settings,
+                draggable: settings.draggable
             });
             $target.data("locationpicker", gmapContext);
             // Subscribe GMap events
@@ -259,6 +260,7 @@
         },
         enableAutocomplete: false,
         enableReverseGeocode: true,
+        draggable: true,
         onchanged: function(currentLocation, radius, isMarkerDropped) {},
         onlocationnotfound: function(locationName) {},
         oninitialized: function (component) {}


### PR DESCRIPTION
locationpicker has a new setting called draggable which can be used while initializing to enable or disable the dragging of the market. It will be quite handy in case if you want only place to be search or you want to enable it in certain condition only.
