### PR TITLE
Update: Fire change() event on bound input changes

### DIFF
--- a/locationpicker.jquery.js
+++ b/locationpicker.jquery.js
@@ -146,16 +146,16 @@
         if (!inputBinding) return;
         var currentLocation = GmUtility.locationFromLatLng(gmapContext.location);
         if (inputBinding.latitudeInput) {
-            inputBinding.latitudeInput.val(currentLocation.latitude);
+            inputBinding.latitudeInput.val(currentLocation.latitude).change();
         }
         if (inputBinding.longitudeInput) {
-            inputBinding.longitudeInput.val(currentLocation.longitude);
+            inputBinding.longitudeInput.val(currentLocation.longitude).change();
         }
         if (inputBinding.radiusInput) {
-            inputBinding.radiusInput.val(gmapContext.radius);
+            inputBinding.radiusInput.val(gmapContext.radius).change();
         }
         if (inputBinding.locationNameInput) {
-            inputBinding.locationNameInput.val(gmapContext.locationName);
+            inputBinding.locationNameInput.val(gmapContext.locationName).change();
         }
     }
 


### PR DESCRIPTION
This is useful when integrating this plugin into javascript frameworks like Ember.js, Angular etc. In my case I need to trigger further actions when the input field value changes. If you just set the value with `.val()` you're listeners on the input field will not fire. Adding `.change()` enables this behavior.
