### PR TITLE
Handle geolocation of address field on blur

### DIFF
--- a/src/locationpicker.jquery.js
+++ b/src/locationpicker.jquery.js
@@ -192,28 +192,30 @@
                             [GmUtility.locationFromLatLng(context.location), context.radius, false]);
                     });
                 });
-                inputBinding.locationNameInput.on("change", function(e) {
-                  if (!e.originalEvent) { return }
-                  blur = true;
-                });
-                inputBinding.locationNameInput.on("blur", function(e) {
-                  if (!e.originalEvent) { return }
-                  setTimeout(function() {
-                      var address = $(inputBinding.locationNameInput).val();
-                      if (address.length > 5 && blur) {
-                          blur = false;
-                          gmapContext.geodecoder.geocode({'address': address}, function(results, status) {
-                              if(status == google.maps.GeocoderStatus.OK  && results && results.length) {
-                                  GmUtility.setPosition(gmapContext, results[0].geometry.location, function(context) {
-                                      updateInputValues(inputBinding, context);
-                                      context.settings.onchanged.apply(gmapContext.domContainer,
-                                          [GmUtility.locationFromLatLng(context.location), context.radius, false]);
-                                  });
-                              }
-                          });
-                      }
-                  }, 1000);
-                });
+                if(gmapContext.settings.enableAutocompleteBlur) {
+                  inputBinding.locationNameInput.on("change", function(e) {
+                    if (!e.originalEvent) { return }
+                    blur = true;
+                  });
+                  inputBinding.locationNameInput.on("blur", function(e) {
+                    if (!e.originalEvent) { return }
+                    setTimeout(function() {
+                        var address = $(inputBinding.locationNameInput).val();
+                        if (address.length > 5 && blur) {
+                            blur = false;
+                            gmapContext.geodecoder.geocode({'address': address}, function(results, status) {
+                                if(status == google.maps.GeocoderStatus.OK  && results && results.length) {
+                                    GmUtility.setPosition(gmapContext, results[0].geometry.location, function(context) {
+                                        updateInputValues(inputBinding, context);
+                                        context.settings.onchanged.apply(gmapContext.domContainer,
+                                            [GmUtility.locationFromLatLng(context.location), context.radius, false]);
+                                    });
+                                }
+                            });
+                        }
+                    }, 1000);
+                  });
+                }
             }
             if (inputBinding.latitudeInput) {
                 inputBinding.latitudeInput.on("change", function(e) {
@@ -369,6 +371,7 @@
             locationNameInput: null
         },
         enableAutocomplete: false,
+        enableAutocompleteBlur: false,
         enableReverseGeocode: true,
         draggable: true,
         onchanged: function(currentLocation, radius, isMarkerDropped) {},

--- a/src/locationpicker.jquery.js
+++ b/src/locationpicker.jquery.js
@@ -177,8 +177,10 @@
                 });
             }
             if (inputBinding.locationNameInput && gmapContext.settings.enableAutocomplete) {
+                var blur = false;
                 gmapContext.autocomplete = new google.maps.places.Autocomplete(inputBinding.locationNameInput.get(0));
                 google.maps.event.addListener(gmapContext.autocomplete, 'place_changed', function() {
+                    blur = false;
                     var place = gmapContext.autocomplete.getPlace();
                     if (!place.geometry) {
                         gmapContext.settings.onlocationnotfound(place.name);
@@ -189,6 +191,28 @@
                         context.settings.onchanged.apply(gmapContext.domContainer,
                             [GmUtility.locationFromLatLng(context.location), context.radius, false]);
                     });
+                });
+                inputBinding.locationNameInput.on("change", function(e) {
+                  if (!e.originalEvent) { return }
+                  blur = true;
+                });
+                inputBinding.locationNameInput.on("blur", function(e) {
+                  if (!e.originalEvent) { return }
+                  setTimeout(function() {
+                      var address = $(inputBinding.locationNameInput).val();
+                      if (address.length > 5 && blur) {
+                          blur = false;
+                          gmapContext.geodecoder.geocode({'address': address}, function(results, status) {
+                              if(status == google.maps.GeocoderStatus.OK  && results && results.length) {
+                                  GmUtility.setPosition(gmapContext, results[0].geometry.location, function(context) {
+                                      updateInputValues(inputBinding, context);
+                                      context.settings.onchanged.apply(gmapContext.domContainer,
+                                          [GmUtility.locationFromLatLng(context.location), context.radius, false]);
+                                  });
+                              }
+                          });
+                      }
+                  }, 1000);
                 });
             }
             if (inputBinding.latitudeInput) {


### PR DESCRIPTION
I added a blur handler to geolocate text entered into an address field when a user doesn't choose an option from a google autocomplete dropdown.

This is similar to a previous pull request that was accepted, but then removed in a later commit.

Let me know what you think of this feature, or if there is a better way to integrate it.