### PR TITLE
Updated devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-concat": "^0.4.0",
-    "grunt-contrib-uglify": "^0.4.0",
-    "load-grunt-tasks": "^0.4.0"
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-concat": "^0.5.0",
+    "grunt-contrib-uglify": "^0.8.0",
+    "load-grunt-tasks": "^3.1.0"
   }
 }


### PR DESCRIPTION
grunt-contrib-uglify v0.4.0 doesn't work with node v0.12.0