### PR TITLE
Style overrides for Bootstrap modal example

### DIFF
--- a/examples/mapInModalDialog.html
+++ b/examples/mapInModalDialog.html
@@ -11,6 +11,12 @@
     <script src="../dist/locationpicker.jquery.min.js"></script>
     <title>Simple example</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        /* style overrides for bootstrap/google map conflicts */
+        .gm-style img {max-width: none;}
+        .gm-style label {width: auto; display:inline;} 
+        .pac-container {z-index:2000 !important;}
+    </style>
 </head>
 <body>
 <button data-target="#us6-dialog" data-toggle="modal">Click hear to open dialog</button>


### PR DESCRIPTION
With Bootstrap 3.3.4 the map zoom controls are stretched or invisible and the auto-complete list does not appear due to z-index. These style overrides fix those issues.