### PR TITLE
Remove reference to 'google' object in locationpicker.defaults

### DIFF
--- a/src/locationpicker.jquery.js
+++ b/src/locationpicker.jquery.js
@@ -436,7 +436,7 @@
         locationName: "",
         radius: 500,
         zoom: 15,
-        mapTypeId: google.maps.MapTypeId.ROADMAP,
+        mapTypeId: 'roadmap',
         styles: [],
         mapOptions: {},
         scrollwheel: true,


### PR DESCRIPTION
Remove reference to the global 'google' object in locationpicker.defaults to fix problem with 'google not defined' error when using 'async defer' to load the google maps script.

When loading the google maps scripts with 'async defer', the 'google' global object may not be defined at the moment that the locationpicker.jquery script is loaded. Thus, any reference to the 'google' object must be tied to the callback function provided to the google maps script load:
   <script async defer
	src="http://maps.googleapis.com/maps/api/js?key=APIKEY&callback=initCallbackFunction"
	></script>

The only place that this is a problem is in locationpicker's 'locationpicker.defaults' initialization, which can possibly run before 'google' has been defined. The problem is that this code references 'google.maps.MapTypeId.ROADMAP'. By changing this to the string that this constant defines - 'roadmap' - we eliminate any reference to 'google' until we actually utilize the locationpicker function, which can be tied to the callback function, which guarantees that 'google' is defined.
